### PR TITLE
DORM default adapter in master branch might be changed to Firebird

### DIFF
--- a/source/dorm.INC
+++ b/source/dorm.INC
@@ -9,7 +9,7 @@
   then remove the period before the $ that makes the
   define a comment.
 }
-{.$DEFINE LINK_FIREBIRDUIB_ADAPTER }
+{$DEFINE LINK_FIREBIRDUIB_ADAPTER }
 {.$DEFINE LINK_INTERBASEUIB_ADAPTER }
 {.$DEFINE LINK_SQLITE3_ADAPTER }
 {.$DEFINE LINK_SQLSERVER_ADAPTER } // require delphi ent or better
@@ -21,7 +21,7 @@
 // require delphi ent or better (deprecated, do not use. Use LINK_INTERBASEUIB_ADAPTER)
 
 // requires FireDac for sqlserver
-{$DEFINE LINK_SQLSERVER_FIREDAC_ADAPTER }
+{.$DEFINE LINK_SQLSERVER_FIREDAC_ADAPTER }
 
 { **************** end adapters section ************************* }
 


### PR DESCRIPTION
The main idea is that users who don't have enterprise editions of IDE face compilation errors:

[dcc32 Fatal Error] dorm.adapter.FireDac.SQLServer.pas(8): F2613 Unit 'FireDAC.Phys.MSSQL' not found.

Which  is caused by the fact that MS SQL connection feature is not provided for pro and community version users.

https://www.embarcadero.com/products/rad-studio/firedac